### PR TITLE
Update model_zoo.py to correctly import package

### DIFF
--- a/utils/model_zoo.py
+++ b/utils/model_zoo.py
@@ -16,8 +16,7 @@ import utils.models.hendrycks as hendrycks
 import utils.models.resnet as rn
 import utils.models.modules_ibp as ibp
 import paths_config
-import utils.factories as fac
-
+from utils import factories as fac
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""


### PR DESCRIPTION
```import utils.factories as fac``` should be replaced with ```from utils import factories as fac``` since the former will cause ```AttributeError: module 'utils' has no attribute 'factories```